### PR TITLE
lots of bugs

### DIFF
--- a/src/com/git/ifly6/communique/CommuniqueParser.java
+++ b/src/com/git/ifly6/communique/CommuniqueParser.java
@@ -27,8 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.git.ifly6.javatelegram.util.JInfoFetcher;
 
-/**
- * This class is the central hub of the Communiqué system. It parses the <code>String</code> given to it with all the
+/** This class is the central hub of the Communiqué system. It parses the <code>String</code> given to it with all the
  * recipients (and tags which stand in for multiple recipients) into a <code>String[]</code> which has every single
  * recipient, expanded, on each index. It also handles the removal of certain recipients from the list and filtering of
  * recipients as well.
@@ -77,95 +76,87 @@ import com.git.ifly6.javatelegram.util.JInfoFetcher;
  * negation for that tag only.</td>
  * </tr>
  * </table>
- */
+*/
 public class CommuniqueParser {
 	
-	/**
-	 * This <code>int</code> determines what version of the parser is currently being used. The entire program is build
+	/** This <code>int</code> determines what version of the parser is currently being used. The entire program is build
 	 * around this string for extended compatibility purposes. However, due to the separation between the parser itself
-	 * and the IO system, either of them can trigger a change in the version number.
-	 */
+	 * and the IO system, either of them can trigger a change in the version number. */
 	public static final int version = 6;
-	private static JInfoFetcher fetcher = new JInfoFetcher();
-	
-	/**
-	 * Determine whether a <code>String</code> is a special tag or not. What strings are tags is determined in the
+	private static JInfoFetcher fetcher = JInfoFetcher.getInstance();
+
+	/** Determine whether a <code>String</code> is a special tag or not. What strings are tags is determined in the
 	 * documentation on the grammar of the Communiqué syntax.
 	 *
 	 * @param input
-	 * @return
-	 */
+	 * @return */
 	private boolean isTag(String input) {
 		
 		if (input.startsWith("region:")) {
 			return true;
-			
+
 		} else if (input.equalsIgnoreCase("wa:delegates")) {
 			return true;
-			
+
 		} else if (input.equalsIgnoreCase("wa:nations") || input.equalsIgnoreCase("wa:members")) {
 			return true;
-			
+
 		} else if (input.equalsIgnoreCase("world:new")) { return true; }
-		
+
 		return false;
 	}
-	
-	/**
-	 * Expands a single Communique tag into a list of nations represented by that tag. For example, something like
+
+	/** Expands a single Communique tag into a list of nations represented by that tag. For example, something like
 	 * <code>region:Europe</code> would result in a <code>List&lt;String&gt;</code> of all nations in Europe. Other
 	 * elements, like <code>wa:delegates</code> would yield all the delegates in the World Assembly.
 	 *
 	 * @param tag to be expanded
-	 * @return a <code>List&lt;String&gt;</code> of nations represented
-	 */
+	 * @return a <code>List&lt;String&gt;</code> of nations represented */
 	private List<String> expandTag(String tag) {
 		
 		if (tag.startsWith("region:")) {
 			List<String> regionContentsArr = fetcher.getRegion(tag.replace("region:", ""));
 			return regionContentsArr;
-			
+
 		} else if (tag.startsWith("wa:delegate")) {
 			List<String> delegatesArr = fetcher.getDelegates();
 			return delegatesArr;
-			
+
 		} else if (tag.equals("wa:nations") || tag.equals("wa:members")) {
 			List<String> waNationsArr = fetcher.getWAMembers();
 			return waNationsArr;
-			
+
 		} else if (tag.equals("world:new")) {
 			List<String> newNationsArr = fetcher.getNew();
 			return newNationsArr;
 		}
-		
+
 		// If all else fails...
 		return new ArrayList<String>(0);
 	}
-	
-	/**
-	 * Expands the <code>List&lt;String&gt;</code> into a list of nations based on the tags, operators, etc. If you give
-	 * it something like <code>region:europe</code>, then you'll get back the entire list of nations in Europe. It is
-	 * provided as a list of tags, each on a list. This processes the operators.
+
+	/** Expands the <code>List&lt;String&gt;</code> into a list of nations based on the tags, operators, etc. If you
+	 * give it something like <code>region:europe</code>, then you'll get back the entire list of nations in Europe. It
+	 * is provided as a list of tags, each on a list. This processes the operators.
 	 *
-	 * @param tagsList a <code>List&lt;String&gt;</code> of tags
-	 */
+	 * @param tagsList a <code>List&lt;String&gt;</code> of tags */
 	private Set<String> expandList(List<String> tagsList) {
 		List<String> expandedList = new ArrayList<String>();
-		
+
 		for (int x = 0; x < tagsList.size(); x++) {
 			String element = tagsList.get(x).toLowerCase();
-			
+
 			// Operator meaning 'region:europe->wa:nations' would be 'those in Europe in (who are) WA nations'
 			if (element.contains("->") || element.contains("--")) {
 				
 				String[] bothArr = new String[2];
 				if (element.contains("->")) {
 					bothArr = element.split("->");
-					
+
 				} else if (element.contains("--")) {
 					bothArr = element.split("--");
 				}
-				
+
 				// Remove leading and trailing underscores.
 				for (int i = 0; i < bothArr.length; i++) {
 					bothArr[i] = bothArr[i].trim();
@@ -176,14 +167,14 @@ public class CommuniqueParser {
 						bothArr[i] = bothArr[i].substring(0, bothArr[i].length() - 1);
 					}
 				}
-				
+
 				// Split into the two lists
 				// firsts and seconds refer to the elements on either side of the '->' or '--' operator
 				Set<String> firsts = new HashSet<>(expandTag(bothArr[0]));
 				Set<String> seconds = new HashSet<>(expandTag(bothArr[1]));
-				
+
 				List<String> both = new ArrayList<String>(0);
-				
+
 				// This section is for the addition and subtraction operators
 				if (element.contains("->")) {
 					
@@ -194,7 +185,7 @@ public class CommuniqueParser {
 							both.add(second);
 						}
 					}
-					
+
 				} else if (element.contains("--")) {
 					
 					// If an element in the first list is also contained in the second list, do not add it to the 'both'
@@ -204,27 +195,26 @@ public class CommuniqueParser {
 							both.add(first);
 						}
 					}
-					
+
 				}
-				
+
 				expandedList.addAll(both);
-				
+
 			} else if (isTag(element)) {
 				expandedList.addAll(expandTag(element));
-				
+
 			} else {
 				expandedList.add(element);
 			}
 		}
-		
+
 		// Remove duplicates & return
 		LinkedHashSet<String> tagsSet = new LinkedHashSet<String>();
 		tagsSet.addAll(expandedList);
 		return tagsSet;
 	}
-	
-	/**
-	 * This parses the entire contents of the recipients and allows us to actually make the tag system work through
+
+	/** This parses the entire contents of the recipients and allows us to actually make the tag system work through
 	 * interfacing with the expansion system above. Note that this method automatically handles the removal of commented
 	 * lines with <code>#</code> as the comment. This method calls all other methods to process all of the recipients.
 	 *
@@ -236,40 +226,37 @@ public class CommuniqueParser {
 	 * </p>
 	 *
 	 * @param input an array of the recipients, each one on an individual index, which can include commented lines
-	 * @return a final array of the recipients, compatible with JavaTelegram
-	 */
+	 * @return a final array of the recipients, compatible with JavaTelegram */
 	public String[] filterAndParse(String[] input) {
 		
 		// Filter out comments and empty lines
 		input = Arrays.stream(input).filter(p -> !p.startsWith("#") && !StringUtils.isEmpty(p)).toArray(String[]::new);
-		
+
 		// Form a list of all the nation we want in this list.
 		List<String> recipients = Arrays.stream(input).filter(s -> !s.startsWith("/")).collect(Collectors.toList());
 		recipients.stream().forEach(s -> s.toLowerCase().replace(" ", "_").trim());
-		
+
 		// Form a list of all nations we can't have in this list.
 		List<String> sentList = Arrays.stream(input).filter(s -> s.startsWith("/")).collect(Collectors.toList());
 		sentList.stream().forEach(s -> s.replaceFirst("/", "").toLowerCase().trim().replace(" ", "_"));
-		
+
 		List<String> list = recipientsParse(recipients, sentList);
 		return list.toArray(new String[list.size()]);
 	}
-	
-	/**
-	 * This method parses the recipients based on the list of recipients and the list of nations to which a telegram has
-	 * already been sent. Recipients and sent-s are in tag-form when provided, they are automatically expanded. This
+
+	/** This method parses the recipients based on the list of recipients and the list of nations to which a telegram
+	 * has already been sent. Recipients and sent-s are in tag-form when provided, they are automatically expanded. This
 	 * method requires that they are separated individually into two lists.
 	 *
 	 * @param recipients
 	 * @param sentList
-	 * @return a <code>List</code> containing the recipients in <code>String</code> format.
-	 */
+	 * @return a <code>List</code> containing the recipients in <code>String</code> format. */
 	public List<String> recipientsParse(List<String> recipients, List<String> sentList) {
 		
 		// Expand the lists.
 		Set<String> recipientsExpanded = expandList(recipients);
 		Set<String> sentlistExpanded = expandList(sentList);
-		
+
 		// Filter using new algorithm
 		List<String> finalRecipients = new ArrayList<String>();
 		for (String element : recipientsExpanded) {
@@ -277,17 +264,15 @@ public class CommuniqueParser {
 				finalRecipients.add(element);
 			}
 		}
-		
+
 		return finalRecipients;
 	}
-	
-	/**
-	 * Convenience method for <code>recipientsParse(String[] input)</code> if you don't feel like rewriting the code to
+
+	/** Convenience method for <code>recipientsParse(String[] input)</code> if you don't feel like rewriting the code to
 	 * make it an actual <code>String</code>.
 	 *
 	 * @param input A <code>String</code>, with each line separated by new line.
-	 * @return
-	 */
+	 * @return */
 	@Deprecated public String[] recipientsParse(String input) {
 		return filterAndParse(input.split("\n"));
 	}

--- a/src/com/git/ifly6/communique/ngui/AbstractCommunique.java
+++ b/src/com/git/ifly6/communique/ngui/AbstractCommunique.java
@@ -22,16 +22,18 @@ import com.git.ifly6.communique.io.CLoader;
 
 public abstract class AbstractCommunique {
 	
+	/** Returns a <code>CConfig</code> object which represents the state of the program as it is here.
+	 * @return a <code>CConfig</code> representing the program */
 	public abstract CConfig exportState();
-
+	
 	public abstract void importState(CConfig config);
-
+	
 	public void save(Path savePath) throws IOException {
 		// System.out.println("exportState().sentList\t" + Arrays.toString(exportState().sentList));
 		CLoader loader = new CLoader(savePath);
 		loader.save(exportState());
 	}
-
+	
 	public void load(Path savePath) throws IOException {
 		CLoader loader = new CLoader(savePath);
 		this.importState(loader.load());

--- a/src/com/git/ifly6/communique/ngui/AbstractCommuniqueRecruiter.java
+++ b/src/com/git/ifly6/communique/ngui/AbstractCommuniqueRecruiter.java
@@ -17,6 +17,7 @@ package com.git.ifly6.communique.ngui;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -25,44 +26,43 @@ import com.git.ifly6.javatelegram.util.JInfoFetcher;
 import com.git.ifly6.javatelegram.util.JTelegramException;
 import com.git.ifly6.nsapi.NSNation;
 
-/** @author Kevin */
 public abstract class AbstractCommuniqueRecruiter {
 	
-	public static final JInfoFetcher fetcher = new JInfoFetcher();
-	
+	public static final JInfoFetcher fetcher = JInfoFetcher.getInstance();
+
 	protected String clientKey;
 	protected String secretKey;
 	protected String telegramId;
 	
 	protected List<String> recipients;
-	protected List<String> sentList;
+	protected LinkedHashSet<String> sentList;
 	protected Set<String> proscribedRegions;
-	
+
 	public void setWithCConfig(CConfig config) {
 		
 		setClientKey(config.keys.getClientKey());
 		setSecretKey(config.keys.getSecretKey());
 		setTelegramId(config.keys.getTelegramId());
-		
+
 		recipients = new ArrayList<>(Arrays.asList(config.recipients));
-		sentList = new ArrayList<>(Arrays.asList(config.sentList));
-		
+		sentList = new LinkedHashSet<>(Arrays.asList(config.sentList));
+
 	}
-	
+
 	public void setClientKey(String key) {
 		this.clientKey = key;
 	}
-	
+
 	public void setSecretKey(String key) {
 		this.secretKey = key;
 	}
-	
+
 	public void setTelegramId(String id) {
 		this.telegramId = id;
 	}
-	
+
 	public abstract void send();
-	
+
 	/** Returns a recipient based on the new recipients list from the NS API, filtered by whether it is proscribed. Note
 	 * that any issues or problems are dealt with my defaulting to the newest nation, ignoring the proscription filter.
 	 *
@@ -72,31 +72,29 @@ public abstract class AbstractCommuniqueRecruiter {
 		try {
 			
 			recipients = fetcher.getNew();
-
+			
 			for (String element : recipients) {
 				
 				boolean match = true;
-				if (sentList.contains(element)) {
-					match = false;
-				}
-				if (isProscribed(element, proscribedRegions)) {
-					match = false;
-				}
+				
+				// @formatter:off
+				if (sentList.contains(element)) { match = false; }
+				if (isProscribed(element)) { match = false; }
+
 				try {
-					if (new NSNation(element).populateData().isRecruitable()) {
-						match = false;
-					}
+					if (new NSNation(element).populateData().isRecruitable() == false) { match = false; }
 				} catch (IOException e) {
 					// do nothing and assume that the nation can be recruited if an exception is thrown
 				}
+				// @formatter:on
 				
 				// Return if match is still true
 				if (match) { return element; }
 			}
-
+			
 			// If the filtering failed, then simply just return the newest nation.
 			return recipients.get(0);
-
+			
 		} catch (JTelegramException e) {
 			e.printStackTrace();
 			System.err.println("Error. Retrying recipients list.");
@@ -105,14 +103,14 @@ public abstract class AbstractCommuniqueRecruiter {
 			return getRecipient();
 		}
 	}
-	
+
 	/** Determines whether a nation is in a region excluded by the JList <code>excludeList</code>. This method acts with
 	 * two assumptions: (1) it is not all right to telegram to anyone who resides in a prescribed region and (2) if they
 	 * moved out of the region since founding, it is certainly all right to do so.
 	 *
 	 * @param nationName
 	 * @return <code>boolean</code> on whether it is proscribed */
-	public boolean isProscribed(String element, Set<String> proscribedRegions) {
+	public boolean isProscribed(String element) {
 		
 		NSNation nation = new NSNation(element);
 		try {
@@ -121,13 +119,13 @@ public abstract class AbstractCommuniqueRecruiter {
 			// Failure to fetch information means false
 			return false;
 		}
-		
+
 		String nRegion = nation.getRegion().replaceAll(" ", "_");
 		for (String proscribedRegion : proscribedRegions) {
 			if (proscribedRegion.replaceAll(" ", "_").equalsIgnoreCase(nRegion)) { return true; }
 		}
-		
+
 		return false;
 	}
-	
+
 }

--- a/src/com/git/ifly6/communique/ngui/Communique.java
+++ b/src/com/git/ifly6/communique/ngui/Communique.java
@@ -83,36 +83,36 @@ import com.git.ifly6.javatelegram.JavaTelegram;
 public class Communique extends AbstractCommunique implements JTelegramLogger {
 	
 	private static final Logger log = Logger.getLogger(Communique.class.getName());
-	
+
 	private boolean parsed = false;
 	private JavaTelegram client;
 	private Thread sendingThread = new Thread();
-	
+
 	private JFrame frame;
 	private JPanel recipientsPanel;
-	
+
 	private JTextField txtClientKey;
 	private JTextField txtSecretKey;
 	private JTextField txtTelegramId;
-	
+
 	private JButton btnSend;
 	private JProgressBar progressBar;
 	private JTextArea txtrCode;
-	
+
 	private JCheckBoxMenuItem chckbxmntmRandomiseRecipients;
 	private JCheckBox chckbxRecruitment;
-	
+
 	private String[] parsedRecipients;
-	
+
 	public static Path appSupport;
-	
+
 	private static String codeHeader = "# == Communiqué Recipients Code ==\n"
 			+ "# Enter recipients, one for each line or use 'region:', 'WA:',\n"
 			+ "# etc tags. Use '/' to say: 'not'. Ex: 'region:europe',\n"
 			+ "# '/imperium anglorum'. Use 'flag:recruit' to open the \n" + "# recruiter. \n\n";
-	
+
 	private CommuniqueRecruiter recruiter;
-	
+
 	/** Launch the application. */
 	public static void main(String[] args) {
 		
@@ -120,7 +120,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			
 			// Set system look and feel.
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-
+			
 		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException
 				| UnsupportedLookAndFeelException lfE) {
 			
@@ -132,28 +132,28 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 				e.printStackTrace();
 			}
 			lfE.printStackTrace();
-			
+
 		}
-		
+
 		if (SystemUtils.IS_OS_WINDOWS) {
 			appSupport = Paths.get(System.getenv("LOCALAPPDATA"), "Communique");
-			
+
 		} else if (SystemUtils.IS_OS_MAC) {
 			appSupport = Paths.get(System.getProperty("user.home"), "Library", "Application Support", "Communique");
 			System.setProperty("apple.laf.useScreenMenuBar", "true");
 			System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Communiqué " + CommuniqueParser.version);
-			
+
 		} else {
 			appSupport = Paths.get(System.getProperty("user.dir"), "config");
 		}
-		
+
 		try {
 			Files.createDirectories(appSupport);
 		} catch (IOException e1) {
 			e1.printStackTrace();
 			log.warning("Cannot create directory");
 		}
-		
+
 		EventQueue.invokeLater(() -> {
 			try {
 				Communique window = new Communique();
@@ -163,7 +163,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 	}
-	
+
 	/** Create the application.
 	 *
 	 * @wbp.parser.entryPoint */
@@ -171,9 +171,9 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		
 		client = new JavaTelegram(this);
 		initialise();
-		
+
 	}
-	
+
 	/** Initialise the contents of the frame. */
 	private void initialise() {
 		
@@ -181,26 +181,26 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		if (!SystemUtils.IS_OS_MAC) {
 			frame.setIconImage(new ImageIcon(getClass().getResource("/icon.png")).getImage());
 		}
-		
+
 		Dimension screenDimensions = Toolkit.getDefaultToolkit().getScreenSize();
 		double sWidth = screenDimensions.getWidth();
 		double sHeight = screenDimensions.getHeight();
-		
+
 		frame.setTitle("Communiqué " + CommuniqueParser.version);
 		frame.setBounds(100, 100, (int) Math.round(2 * sWidth / 3), (int) Math.round(2 * sHeight / 3));
 		frame.setMinimumSize(new Dimension(600, 400));
 		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		
+
 		JPanel contentPane = new JPanel();
 		contentPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		frame.setContentPane(contentPane);
-		
+
 		contentPane.setLayout(new BorderLayout(5, 5));
-		
+
 		JPanel controlPanel = new JPanel();
 		contentPane.add(controlPanel, BorderLayout.SOUTH);
 		controlPanel.setLayout(new GridLayout(1, 0, 0, 0));
-		
+
 		txtClientKey = new JTextField();
 		txtClientKey.setFont(new Font(Font.MONOSPACED, 0, 11));
 		txtClientKey.setText(CLoader.readProperties());
@@ -212,7 +212,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		});
 		controlPanel.add(txtClientKey);
 		txtClientKey.setColumns(10);
-		
+
 		txtSecretKey = new JTextField();
 		txtSecretKey.setFont(new Font(Font.MONOSPACED, 0, 11));
 		txtSecretKey.setText("Secret Key");
@@ -224,7 +224,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		});
 		controlPanel.add(txtSecretKey);
 		txtSecretKey.setColumns(10);
-		
+
 		txtTelegramId = new JTextField();
 		txtTelegramId.setFont(new Font(Font.MONOSPACED, 0, 11));
 		txtTelegramId.setText("Telegram ID");
@@ -236,44 +236,44 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		});
 		controlPanel.add(txtTelegramId);
 		txtTelegramId.setColumns(10);
-		
+
 		btnSend = new JButton("Parse");
-		
+
 		chckbxRecruitment = new JCheckBox("Recruit Ratelimit");
 		chckbxRecruitment.addActionListener(l -> {
 			triggerParsed(false);
 		});
 		controlPanel.add(chckbxRecruitment);
 		controlPanel.add(btnSend);
-		
+
 		JPanel metaDataPanel = new JPanel();
 		metaDataPanel.setLayout(new BorderLayout());
 		contentPane.add(metaDataPanel, BorderLayout.CENTER);
-		
+
 		JPanel dataPanel = new JPanel();
 		metaDataPanel.add(dataPanel, BorderLayout.CENTER);
 		dataPanel.setLayout(new GridLayout(1, 0, 5, 5));
-		
+
 		txtrCode = new JTextArea();
 		txtrCode.setText(codeHeader);
 		txtrCode.setFont(new Font(Font.MONOSPACED, 0, 11));
 		txtrCode.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		dataPanel.add(new JScrollPane(txtrCode));
-		
+
 		// Document listener logic
 		txtrCode.getDocument().addDocumentListener(new DocumentListener() {
 			
 			@Override public void removeUpdate(DocumentEvent e) {
 				executeInTheKingdomOfNouns();
 			}
-			
+
 			@Override public void insertUpdate(DocumentEvent e) {
 				executeInTheKingdomOfNouns();
 			}
-			
+
 			@Override public void changedUpdate(DocumentEvent e) {
 			}
-			
+
 			// It's a joke, look here: http://steve-yegge.blogspot.com/2006/03/execution-in-kingdom-of-nouns.html
 			public void executeInTheKingdomOfNouns() {
 				if (parsed) {	// to avoid constant resetting of the variable
@@ -281,38 +281,38 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 				}
 			}
 		});
-		
+
 		recipientsPanel = new JPanel();
 		dataPanel.add(recipientsPanel);
 		recipientsPanel.setLayout(new BorderLayout(0, 0));
-		
+
 		JTextArea txtrRecipients = new JTextArea();
 		txtrRecipients.setText(
 				"# == Communiqué Recipients ==\n# This tab shows all recipients after parsing of the Code tab.\n\n");
 		txtrRecipients.setFont(new Font(Font.MONOSPACED, 0, 11));
 		txtrRecipients.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		recipientsPanel.add(new JScrollPane(txtrRecipients), BorderLayout.CENTER);
-		
+
 		progressBar = new JProgressBar();
 		progressBar.setBorder(BorderFactory.createEmptyBorder(0, 3, 0, 3));
 		metaDataPanel.add(progressBar, BorderLayout.SOUTH);
-		
+
 		JMenuBar menuBar = new JMenuBar();
 		frame.setJMenuBar(menuBar);
-		
+
 		JMenu mnFile = new JMenu("File");
 		menuBar.add(mnFile);
-		
+
 		JMenuItem mntmSave = new JMenuItem("Save");
 		mntmSave.setAccelerator(getOSKeyStroke(KeyEvent.VK_S));
 		mntmSave.addActionListener(e -> {
 			Path savePath = showFileChooser(frame, FileDialog.SAVE);
-			
+
 			if (savePath == null) {
 				log.info("Returned path was null.");
 				return;
 			}
-			
+
 			try {
 				Communique.this.save(savePath);
 			} catch (IOException e1) {
@@ -320,17 +320,17 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnFile.add(mntmSave);
-		
+
 		JMenuItem mntmOpen = new JMenuItem("Open");
 		mntmOpen.setAccelerator(getOSKeyStroke(KeyEvent.VK_O));
 		mntmOpen.addActionListener(e -> {
 			Path savePath = showFileChooser(frame, FileDialog.LOAD);
-			
+
 			if (savePath == null) {
 				log.info("Returned path was null.");
 				return;
 			}
-			
+
 			try {
 				Communique.this.load(savePath);
 			} catch (IOException e1) {
@@ -338,9 +338,9 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnFile.add(mntmOpen);
-		
+
 		mnFile.addSeparator();
-		
+
 		JMenuItem mntmClose = new JMenuItem("Close");
 		mntmClose.setAccelerator(getOSKeyStroke(KeyEvent.VK_W));
 		mntmClose.addActionListener(e -> {
@@ -349,9 +349,9 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			System.exit(0);
 		});
 		mnFile.add(mntmClose);
-		
+
 		mnFile.addSeparator();
-		
+
 		JMenuItem mntmShowDirectory = new JMenuItem("Show Directory");
 		mntmShowDirectory.setAccelerator(getOSKeyStroke(KeyEvent.VK_O, true));
 		mntmShowDirectory.addActionListener(e -> {
@@ -362,7 +362,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnFile.add(mntmShowDirectory);
-		
+
 		// Only add the Quit menu item if the OS is not Mac
 		if (!SystemUtils.IS_OS_MAC) {
 			mnFile.addSeparator();
@@ -371,29 +371,29 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			mntmExit.addActionListener(e -> System.exit(0));
 			mnFile.add(mntmExit);
 		}
-		
+
 		JMenu mnData = new JMenu("Data");
 		menuBar.add(mnData);
-		
+
 		JMenuItem mntmImportKeysFrom = new JMenuItem("Import Keys from Telegram URL");
 		mntmImportKeysFrom.addActionListener(e -> {
 			
 			String rawURL = JOptionPane
 					.showInputDialog("Paste in keys from the URL provided by receipt by the Telegrams API");
-			
+
 			// Verify that it is a valid NationStates URL
 			String rawUrlStart = "http://www.nationstates.net/cgi-bin/api.cgi?a=sendTG&client=YOUR_API_CLIENT_KEY&";
 			if (rawURL.startsWith(rawUrlStart)) {
 				
 				rawURL = rawURL.replace(rawUrlStart, "");
 				rawURL = rawURL.replace("&to=NATION_NAME", "");
-				
+
 				String[] tags = rawURL.split("&");
 				if (tags.length == 2) {
 					txtTelegramId.setText(tags[0].substring(tags[0].indexOf("=") + 1, tags[0].length()));
 					txtSecretKey.setText(tags[1].substring(tags[1].indexOf("=") + 1, tags[1].length()));
 				}
-				
+
 			} else {
 				String message = "<html>Please input a properly formatted NationStates URL in the form displayed when a "
 						+ "telegram is sent to 'tag:api'</html>";
@@ -401,13 +401,13 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnData.add(mntmImportKeysFrom);
-		
+
 		JMenu mnImportRecipients = new JMenu("Import Recipients");
 		mnData.add(mnImportRecipients);
-		
+
 		JMenuItem mntmFromWaDelegate = new JMenuItem("From WA Delegate List");
 		mntmFromWaDelegate.addActionListener(e -> appendCode("wa:delegates"));
-		
+
 		JMenuItem mntmAsCommaSeparated = new JMenuItem("As Comma Separated List");
 		mntmAsCommaSeparated.addActionListener(e -> {
 			String message = "Input a string of delegates, as found on a list of delegates\nin one of the "
@@ -417,7 +417,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 				
 				input = input.replaceAll("\\(.+?\\)", "");
 				String[] list = input.split(",");
-				
+
 				for (String element : list) {
 					appendCode(element.toLowerCase().trim().replace(" ", "_"));
 				}
@@ -425,21 +425,21 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		});
 		mnImportRecipients.add(mntmAsCommaSeparated);
 		mnImportRecipients.add(mntmFromWaDelegate);
-		
+
 		JMenuItem mntmFromAtVote = new JMenuItem("From At Vote Screen");
 		mntmFromAtVote.addActionListener(e -> {
 			
 			Object[] possibilities = { "GA For", "GA Against", "SC For", "SC Against" };
 			String output = (String) JOptionPane.showInputDialog(frame, "Select which chamber and side you want to address:",
 					"Select Chamber and Side", JOptionPane.PLAIN_MESSAGE, null, possibilities, "GA For");
-			
+
 			if (!StringUtils.isEmpty(output)) {
 				String[] elements = output.split(" ");
 				if (elements.length == 2) {
 					
 					String chamber = elements[0].equals("GA") ? CNetLoader.GA : CNetLoader.SC;
 					String side = elements[1].equals("For") ? CNetLoader.FOR : CNetLoader.AGAINST;
-					
+
 					try {
 						txtrCode.append(CommuniqueUtilities
 								.joinListWith(Arrays.asList(CNetLoader.importAtVoteDelegates(chamber, side)), '\n'));
@@ -447,15 +447,15 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 						JOptionPane.showMessageDialog(frame, "Cannot import data from NationStates website.");
 						log.warning("Cannot import data.");
 					}
-					
+
 				}
 			}
-			
+
 		});
 		mnImportRecipients.add(mntmFromAtVote);
-		
-		mnData.addSeparator();
 
+		mnData.addSeparator();
+		
 		// TODO Create a system to help people write their configuration files.
 		// JMenuItem mntmFilter = new JMenuItem("Filter");
 		// mntmFilter.setAccelerator(getOSKeyStroke(KeyEvent.VK_F));
@@ -465,13 +465,13 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		// mnData.add(mntmFilter);
 		//
 		// mnData.addSeparator();
-		
+
 		chckbxmntmRandomiseRecipients = new JCheckBoxMenuItem("Randomise Recipients");
 		mnData.add(chckbxmntmRandomiseRecipients);
-		
+
 		JMenu mnWindow = new JMenu("Window");
 		menuBar.add(mnWindow);
-		
+
 		JMenuItem mntmMinimise = new JMenuItem("Minimise");
 		mntmMinimise.setAccelerator(getOSKeyStroke(KeyEvent.VK_M));
 		mntmMinimise.addActionListener(e -> {
@@ -480,23 +480,23 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnWindow.add(mntmMinimise);
-		
+
 		mnWindow.addSeparator();
-		
+
 		JMenuItem mntmRecruiter = new JMenuItem("Recruiter...");
 		mntmRecruiter.setAccelerator(getOSKeyStroke(KeyEvent.VK_R));
 		mntmRecruiter.addActionListener(e -> showRecruiter());
 		mnWindow.add(mntmRecruiter);
-		
+
 		JMenu mnHelp = new JMenu("Help");
 		menuBar.add(mnHelp);
-		
+
 		JMenuItem mntmAbout = new JMenuItem("About");
 		mntmAbout.addActionListener(e -> new CTextDialog(frame, "About", CommuniqueMessages.acknowledgement));
 		mnHelp.add(mntmAbout);
-		
+
 		mnHelp.addSeparator();
-		
+
 		JMenuItem mntmDocumentation = new JMenuItem("Documentation");
 		mntmDocumentation.addActionListener(e -> {
 			try {
@@ -507,7 +507,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnHelp.add(mntmDocumentation);
-		
+
 		JMenuItem mntmForumThread = new JMenuItem("Forum Thread");
 		mntmForumThread.addActionListener(e -> {
 			try {
@@ -518,13 +518,13 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 		});
 		mnHelp.add(mntmForumThread);
-		
+
 		mnHelp.addSeparator();
-		
+
 		JMenuItem mntmLicence = new JMenuItem("Licence");
 		mntmLicence.addActionListener(e -> new CTextDialog(frame, "Licence", CommuniqueMessages.licence));
 		mnHelp.add(mntmLicence);
-		
+
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			@Override public void run() {
 				try {
@@ -532,21 +532,21 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 					// Save it to application support
 					CLoader loader = new CLoader(appSupport.resolve("autosave.txt"));
 					loader.save(exportState());
-					
+
 				} catch (IOException e) {
 					e.printStackTrace();
 				}
 			}
 		});
 		log.info("Shutdown hook added.");
-		
+
 		// Parse action for above
 		btnSend.addActionListener(new ActionListener() {
 			
 			@Override public void actionPerformed(ActionEvent e) {
 				
 				CommuniqueParser parser = new CommuniqueParser();
-				
+
 				// Check if a recruit-flag has been used.
 				String[] lines = txtrCode.getText().split("\n");
 				for (String element : lines) {
@@ -555,16 +555,16 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 						return;
 					}
 				}
-				
+
 				if (!parsed) {
 					
 					// Call and do the parsing
 					log.info("Called parser");
 					Communique.this.parsedRecipients = parser.filterAndParse(txtrCode.getText().split("\n"));
-					
+
 					// Estimate Time Needed
 					String timeNeeded = estimateTime(parsedRecipients.length, chckbxRecruitment.isSelected());
-					
+
 					// Show Recipients
 					StringBuilder builder = new StringBuilder();
 					builder.append("# == Communiqué Recipients ==\n" + "# This tab shows all " + parsedRecipients.length
@@ -573,27 +573,27 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 					for (String element : parsedRecipients) {
 						builder.append(element + "\n");
 					}
-					
+
 					log.info("Recipients Parsed.");
-					
+
 					// Change GUI elements
 					txtrRecipients.setText(builder.toString());
 					triggerParsed(true);
-					
+
 				} else {
 					send();
 				}
 			}
-			
+
 			private String estimateTime(int count, boolean isRecruitment) {
 				int numRecipients = count;
 				int seconds = (int) Math.round(numRecipients * (isRecruitment ? 180.05 : 30.05));
 				return CommuniqueUtilities.time(seconds);
 			}
 		});
-		
+
 		log.info("Communiqué loaded.");
-		
+
 		// If there is an auto-save, load it
 		if (Files.exists(appSupport.resolve("autosave.txt"))) {
 			CLoader loader = new CLoader(appSupport.resolve("autosave.txt"));
@@ -603,43 +603,43 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 				// do nothing if it fails to load
 			}
 		}
-		
+
 	}
-	
+
 	@Override public CConfig exportState() {
 		
 		CConfig config = new CConfig();
-		
+
 		config.isRecruitment = chckbxRecruitment.isSelected();
 		config.isRandomised = chckbxmntmRandomiseRecipients.isSelected();
 		config.keys = new JTelegramKeys(txtClientKey.getText(), txtSecretKey.getText(), txtTelegramId.getText());
-		
+
 		String[][] recipientsAndSents = filterSents(txtrCode.getText().split("\n"));
-		
+
 		config.recipients = recipientsAndSents[0];
 		config.sentList = recipientsAndSents[1];
-		
+
 		config.defaultVersion();
-		
+
 		log.info("Communiqué config exported.");
 		return config;
-		
+
 	}
-	
+
 	@Override public void importState(CConfig config) {
 		
 		chckbxRecruitment.setSelected(config.isRecruitment);
 		chckbxmntmRandomiseRecipients.setSelected(config.isRandomised);
-		
+
 		txtClientKey.setText(config.keys.getClientKey());
 		txtSecretKey.setText(config.keys.getSecretKey());
 		txtTelegramId.setText(config.keys.getTelegramId());
-		
+
 		// Format the standard recipients.
 		if (!ArrayUtils.isEmpty(config.recipients)) {
 			txtrCode.setText(codeHeader + CommuniqueUtilities.joinListWith(Arrays.asList(config.recipients), '\n'));
 		}
-		
+
 		// Format the universal negations.
 		if (!ArrayUtils.isEmpty(config.sentList)) {
 			for (int x = 0; x < config.sentList.length; x++) {
@@ -647,58 +647,58 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			}
 			txtrCode.append("\n\n" + CommuniqueUtilities.joinListWith(Arrays.asList(config.sentList), '\n'));
 		}
-		
+
 		log.info("Communique info imported");
 	}
-	
+
 	private void appendCode(String input) {
 		txtrCode.append("\n" + input);
 	}
-	
+
 	private String[][] filterSents(String[] input) {
 		
 		List<String> inputList = Arrays.asList(input);
-		
+
 		List<String> recipients = new ArrayList<>();
 		List<String> sents = new ArrayList<>();
-		
+
 		for (int x = 0; x < inputList.size(); x++) {
 			
 			if (!StringUtils.isEmpty(inputList.get(x)) && !inputList.get(x).startsWith("#")) {
 				if (!inputList.get(x).startsWith("/")) {
 					recipients.add(inputList.get(x));
-					
+
 				} else {
 					sents.add(inputList.get(x).replaceFirst("/", ""));
 				}
 			}
 		}
-		
+
 		return new String[][] { recipients.toArray(new String[recipients.size()]), sents.toArray(new String[sents.size()]) };
 	}
-	
+
 	// Changes the state of the button to reflect whether it is ready to send and or parsed
 	void triggerParsed(boolean parsed) {
 		this.parsed = parsed;
 		btnSend.setText(parsed ? "Send" : "Parse");
 	}
-	
+
 	/** @see com.git.ifly6.javatelegram.JTelegramLogger#log(java.lang.String) */
 	@Override public void log(String input) {
 		log.info(input);
 	}
-	
+
 	/** @see com.git.ifly6.javatelegram.JTelegramLogger#sentTo(java.lang.String, int, int) */
 	@Override public void sentTo(String recipient, int x, int length) {
 		
 		if (!(progressBar.getMaximum() == length - 1)) {
 			progressBar.setMaximum(length - 1);
 		}
-		
+
 		txtrCode.append(x == 0 ? "\n\n/" + recipient : "\n/" + recipient);
 		progressBar.setValue(x);
 	}
-	
+
 	/** Shows and initialises the Communique Recruiter.
 	 *
 	 * @since 6
@@ -711,7 +711,7 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			recruiter.toFront();
 		}
 	}
-	
+
 	/** Returns a <code>KeyStroke</code> which is automatically adapted for
 	 *
 	 * @param keyEvent
@@ -728,22 +728,22 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 			return KeyStroke.getKeyStroke(keyEvent, SystemUtils.IS_OS_MAC ? Event.META_MASK : Event.CTRL_MASK);
 		}
 	}
-	
+
 	public static KeyStroke getOSKeyStroke(int keyEvent) {
 		return getOSKeyStroke(keyEvent, false);
 	}
-	
+
 	/** @param type */
 	public Path showFileChooser(Frame parent, int type) {
 		
 		Path savePath;
-		
+
 		// Due to a problem in Windows and the AWT FileDialog, this will show a JFileChooser on Windows systems.
 		if (!SystemUtils.IS_OS_MAC) {
 			
 			JFileChooser fChooser = new JFileChooser(appSupport.toFile());
 			fChooser.setDialogTitle("Choose file...");
-			
+
 			int returnVal = JFileChooser.CANCEL_OPTION;
 			if (type == FileDialog.SAVE) {
 				returnVal = fChooser.showSaveDialog(parent);
@@ -751,31 +751,31 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 				returnVal = fChooser.showOpenDialog(parent);
 			}
 			fChooser.setVisible(true);
-			
+
 			if (returnVal == JFileChooser.APPROVE_OPTION) {
 				savePath = fChooser.getSelectedFile().toPath();
 			} else {
 				return null;
 			}
-			
+
 		} else {
 			
 			FileDialog fDialog = new FileDialog(parent, "Choose file...", type);
 			fDialog.setDirectory(appSupport.toFile().toString());
 			fDialog.setVisible(true);
-			
+
 			String fileName = fDialog.getFile();
 			if (fileName == null) {
 				log.info("User cancelled file file dialog");
 				return null;
-				
+
 			} else {
 				savePath = Paths.get(fDialog.getDirectory() == null ? "" : fDialog.getDirectory())
 						.resolve(fDialog.getFile());
 			}
-			
+
 		}
-		
+
 		// Make it end in txt if saving
 		if (type == FileDialog.SAVE) {
 			if (!FilenameUtils.getExtension(savePath.toString()).equals("txt")) {
@@ -783,12 +783,12 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 				savePath = savePath.resolveSibling(savePath.getFileName() + ".txt");
 			}
 		}
-		
+
 		String action = type == FileDialog.SAVE ? "save" : "load";
 		log.info("User elected to " + action + " file at " + savePath.toAbsolutePath().toString());
 		return savePath;
 	}
-	
+
 	/**
 	 *
 	 */
@@ -797,45 +797,45 @@ public class Communique extends AbstractCommunique implements JTelegramLogger {
 		// sending logic
 		if (!sendingThread.isAlive()) {
 			client.setKillThread(false);
-			
+
 			Runnable runner = () -> {
 				
 				if (chckbxmntmRandomiseRecipients.isSelected()) {
 					CommuniqueUtilities.randomiseArray(parsedRecipients);
 				}
-				
+
 				client.setRecipients(parsedRecipients);	// Set recipients
 				client.setKeys(new JTelegramKeys(txtClientKey.getText(), txtSecretKey.getText(), txtTelegramId.getText()));
-				
+
 				// Set Recruitment Status, JavaTelegram defaults to true
 				client.setRecruitment(chckbxRecruitment.isSelected());
-				
+
 				// Save client key
 				try {
 					CLoader.writeProperties(txtClientKey.getText());
 					CLoader loader = new CLoader(appSupport.resolve("autosave.txt"));
 					loader.save(exportState());
-					
+
 				} catch (IOException e) {
 					System.err.println("Exception in writing autosave or properties file.");
 				}
-				
+
 				client.connect();
 				log.info("Queries Complete.");
 				JOptionPane.showMessageDialog(Communique.this.frame,
 						"Queries to " + (progressBar.getValue() + 1) + " nations complete.");
-				
+
 				// Reset the progress bar
 				progressBar.setValue(0);
 				progressBar.setMaximum(0);
-				
+
 				// Update code has been removed because of a change to the JTelegramLogger which allows
 				// for direct event dispatch.
 			};
-			
+
 			sendingThread = new Thread(runner);
 			sendingThread.start();
-			
+
 		} else {
 			log.info("There is already a campaign running. Terminate that campaign and then retry.");
 		}

--- a/src/com/git/ifly6/marconi/Marconi.java
+++ b/src/com/git/ifly6/marconi/Marconi.java
@@ -18,6 +18,7 @@ package com.git.ifly6.marconi;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -68,7 +69,7 @@ public class Marconi extends AbstractCommunique implements JTelegramLogger {
 				.println(
 						"This will take "
 								+ CommuniqueUtilities.time((int) Math
-										.round(expandedRecipients.size() * ((config.isRecruitment) ? 180.05 : 30.05)))
+										.round(expandedRecipients.size() * (config.isRecruitment ? 180.05 : 30.05)))
 								+ " to send " + expandedRecipients.size() + " telegrams.");
 		
 		if (!skipChecks) {
@@ -88,10 +89,8 @@ public class Marconi extends AbstractCommunique implements JTelegramLogger {
 		client.connect();
 	}
 	
-	/**
-	 * Should the problem be prompted to manually check all flags, this method does so, retrieving the flags and asking
-	 * for the user to reconfirm them.
-	 */
+	/** Should the problem be prompted to manually check all flags, this method does so, retrieving the flags and asking
+	 * for the user to reconfirm them. */
 	public void manualFlagCheck() {
 		
 		if (!skipChecks) {
@@ -127,23 +126,25 @@ public class Marconi extends AbstractCommunique implements JTelegramLogger {
 		}
 	}
 	
-	/**
-	 * @see com.git.ifly6.communique.ngui.AbstractCommunique#exportState()
-	 */
+	/** Note that this will not return what is loaded. It will return a sentList whose duplicates have been removed and,
+	 * if any elements start with a negation <code>/</code>, it will remove it.
+	 * @see com.git.ifly6.communique.ngui.AbstractCommunique#exportState() */
 	@Override public CConfig exportState() {
+		
+		// Remove duplicates from the sentList
+		config.sentList = Stream.of(config.sentList).distinct().map(s -> s.startsWith("/") ? s.substring(1) : s)
+				.toArray(String[]::new);
+		
 		return config;
+		
 	}
 	
-	/**
-	 * @see com.git.ifly6.communique.ngui.AbstractCommunique#importState(com.git.ifly6.communique.io.CConfig)
-	 */
+	/** @see com.git.ifly6.communique.ngui.AbstractCommunique#importState(com.git.ifly6.communique.io.CConfig) */
 	@Override public void importState(CConfig config) {
 		this.config = config;
 	}
 	
-	/**
-	 * @see com.git.ifly6.javatelegram.JTelegramLogger#log(java.lang.String)
-	 */
+	/** @see com.git.ifly6.javatelegram.JTelegramLogger#log(java.lang.String) */
 	@Override public void log(String input) {
 		
 		// If we are recruiting, suppress the API Queries message
@@ -154,9 +155,7 @@ public class Marconi extends AbstractCommunique implements JTelegramLogger {
 		System.out.println("[" + MarconiUtilities.currentTime() + "] " + input);
 	}
 	
-	/**
-	 * @see com.git.ifly6.javatelegram.JTelegramLogger#sentTo(java.lang.String, int, int)
-	 */
+	/** @see com.git.ifly6.javatelegram.JTelegramLogger#sentTo(java.lang.String, int, int) */
 	@Override public void sentTo(String recipient, int x, int length) {
 		config.sentList = ArrayUtils.add(config.sentList, recipient);
 	}

--- a/src/com/git/ifly6/marconi/MarconiRecruiter.java
+++ b/src/com/git/ifly6/marconi/MarconiRecruiter.java
@@ -20,59 +20,51 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.git.ifly6.communique.ngui.AbstractCommuniqueRecruiter;
+import com.git.ifly6.javatelegram.JTelegramLogger;
 import com.git.ifly6.javatelegram.JavaTelegram;
 
-/**
- * @author Kevin
- *
- */
-public class MarconiRecruiter extends AbstractCommuniqueRecruiter {
+/** @author Kevin */
+public class MarconiRecruiter extends AbstractCommuniqueRecruiter implements JTelegramLogger {
 	
 	private Marconi marconi;
 	private Thread thread;
 	
-	/**
-	 * @param marconi
-	 */
+	/** @param marconi */
 	public MarconiRecruiter(Marconi marconi) {
 		this.marconi = marconi;
 	}
 	
-	/**
-	 * @see com.git.ifly6.communique.ngui.AbstractCommuniqueRecruiter#send()
-	 */
+	/** @see com.git.ifly6.communique.ngui.AbstractCommuniqueRecruiter#send() */
 	@Override public void send() {
 		
-		Runnable runner = new Runnable() {
-			@Override public void run() {
+		Runnable runner = () -> {
+			
+			boolean isSending = true;
+			while (isSending) {
 				
-				boolean isSending = true;
-				while (isSending) {
-					
-					proscribedRegions = populateProscribedRegions();
-					String recipient = getRecipient();
-					
-					// Otherwise, start sending.
-					JavaTelegram client = new JavaTelegram(marconi);
-					client.setKeys(marconi.exportState().keys);
-					client.setRecipient(recipient);
-					client.connect();
-					
-					// Report information
-					marconi.log("Sent recruitment telegram " + marconi.exportState().sentList.length + " to " + recipient);
-					
-					Calendar now = Calendar.getInstance();
-					now.add(Calendar.SECOND, 180);
-					String nextTelegramTime = new SimpleDateFormat("HH:mm:ss").format(now.getTime());
-					marconi.log("Next recruitment telegram in 180 seconds at " + nextTelegramTime);
-					
-					try {
-						Thread.sleep(180 * 1000);
-					} catch (InterruptedException e) {
-						// nothing, since it cannot be interrupted.
-					}
-					
+				proscribedRegions = populateProscribedRegions();
+				String recipient = getRecipient();
+				
+				// Otherwise, start sending.
+				JavaTelegram client = new JavaTelegram(this);
+				client.setKeys(marconi.exportState().keys);
+				client.setRecipient(recipient);
+				client.connect();
+				
+				// Report information
+				marconi.log("Sent recruitment telegram " + marconi.exportState().sentList.length + " to " + recipient);
+				
+				Calendar now = Calendar.getInstance();
+				now.add(Calendar.SECOND, 180);
+				String nextTelegramTime = new SimpleDateFormat("HH:mm:ss").format(now.getTime());
+				marconi.log("Next recruitment telegram in 180 seconds at " + nextTelegramTime);
+				
+				try {
+					Thread.sleep(180 * 1000);
+				} catch (InterruptedException e) {
+					// nothing, since it cannot be interrupted.
 				}
+				
 			}
 		};
 		
@@ -96,6 +88,17 @@ public class MarconiRecruiter extends AbstractCommuniqueRecruiter {
 		}
 		
 		return proscribedRegions;
+	}
+	
+	/** @see com.git.ifly6.javatelegram.JTelegramLogger#log(java.lang.String) */
+	@Override public void log(String input) {
+		marconi.log(input);
+	}
+	
+	/** @see com.git.ifly6.javatelegram.JTelegramLogger#sentTo(java.lang.String, int, int) */
+	@Override public void sentTo(String recipient, int x, int length) {
+		marconi.sentTo(recipient, x, length);
+		sentList.add(recipient);
 	}
 	
 }


### PR DESCRIPTION
the filtering mechanism failed. it was fixed. a filter was added to the
output for marconi’s sentList, which now gets rid of duplicates and
deals with some systematic errors from the early days. The JInfoFetcher
is now a singleton object. MarconiRecruiter now directly updates its
own dynamic copy of the sentList, which it did not in the past (because
I fucked up).